### PR TITLE
Add undo/redo UI, JSON utilities, and simplified IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,8 @@
                     </svg>
                 </button>
                 <button class="tool-btn" id="clear-btn" title="Clear">Clear</button>
-                <button class="tool-btn" id="export-btn" title="Export">Export</button>
+                <button class="tool-btn" id="undo-btn" title="Undo">Undo</button>
+                <button class="tool-btn" id="redo-btn" title="Redo">Redo</button>
             </div>
             <canvas id="drawing-canvas"></canvas>
             <div class="status-bar">
@@ -61,6 +62,10 @@
                 <h3>JSON Representation</h3>
                 <button id="format-json">Format</button>
                 <button id="validate-json">Validate</button>
+                <button id="copy-json">Copy</button>
+                <button id="save-json">Save</button>
+                <button id="open-json">Open</button>
+                <input type="file" id="json-file-input" accept="application/json" style="display:none" />
             </div>
             <textarea id="json-editor" spellcheck="false"></textarea>
             <div class="metadata-panel">


### PR DESCRIPTION
## Summary
- Add toolbar buttons for undo/redo and remove export
- Enable copying, saving, and opening JSON via new buttons
- Generate short random entity IDs and simplify constraint display
- Highlight corresponding JSON when entities are hovered or selected on the canvas

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f21eb65a483259d8c42a6c66447bb