### PR TITLE
Add undo/redo UI, JSON utilities, simplified IDs, and dimension entity

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,13 @@
                         <path d="M 3 17 A 10 10 0 0 0 17 3" stroke="currentColor" stroke-width="2" fill="none"/>
                     </svg>
                 </button>
+                <button class="tool-btn" data-tool="dimension" title="Dimension">
+                    <svg width="20" height="20" viewBox="0 0 20 20">
+                        <path d="M4 10 L16 10" stroke="currentColor" stroke-width="2"/>
+                        <path d="M4 10 L7 7 M4 10 L7 13" stroke="currentColor" stroke-width="2"/>
+                        <path d="M16 10 L13 7 M16 10 L13 13" stroke="currentColor" stroke-width="2"/>
+                    </svg>
+                </button>
                 <div class="separator"></div>
                 <button class="tool-btn" id="origin-btn" title="Set Origin">
                     <svg width="20" height="20" viewBox="0 0 20 20">
@@ -48,7 +55,8 @@
                     </svg>
                 </button>
                 <button class="tool-btn" id="clear-btn" title="Clear">Clear</button>
-                <button class="tool-btn" id="export-btn" title="Export">Export</button>
+                <button class="tool-btn" id="undo-btn" title="Undo">Undo</button>
+                <button class="tool-btn" id="redo-btn" title="Redo">Redo</button>
             </div>
             <canvas id="drawing-canvas"></canvas>
             <div class="status-bar">
@@ -61,6 +69,10 @@
                 <h3>JSON Representation</h3>
                 <button id="format-json">Format</button>
                 <button id="validate-json">Validate</button>
+                <button id="copy-json">Copy</button>
+                <button id="save-json">Save</button>
+                <button id="open-json">Open</button>
+                <input type="file" id="json-file-input" accept="application/json" style="display:none" />
             </div>
             <textarea id="json-editor" spellcheck="false"></textarea>
             <div class="metadata-panel">


### PR DESCRIPTION
## Summary
- Add toolbar buttons for undo/redo and remove export
- Enable copying, saving, and opening JSON via new buttons
- Generate short random entity IDs and simplify constraint display
- Highlight corresponding JSON when entities are hovered or selected on the canvas
- Introduce a Dimension tool that draws arrowed measurement lines with automatic length labels
- Prevent canvas-driven JSON highlights from overriding cursor position while the JSON editor is focused
- Normalize entity coordinates on JSON edits so changes like dimensions update the canvas

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f21eb65a483259d8c42a6c66447bb